### PR TITLE
[Code]NLP-4 duplicated code: putting the padded_x to pad again

### DIFF
--- a/nlp-pytorch/4-recurrent-networks.ipynb
+++ b/nlp-pytorch/4-recurrent-networks.ipynb
@@ -342,8 +342,7 @@
     "        batch_size = x.size(0)\n",
     "        x = self.embedding(x)\n",
     "        pad_x = torch.nn.utils.rnn.pack_padded_sequence(x,lengths,batch_first=True,enforce_sorted=False)\n",
-    "        pad_x,(h,c) = self.rnn(pad_x)\n",
-    "        x, _ = torch.nn.utils.rnn.pad_packed_sequence(pad_x,batch_first=True)\n",
+    "        _,(h,c) = self.rnn(pad_x)\n",
     "        return self.fc(h[-1])"
    ]
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21982975/126524574-b7eb481b-426b-4890-89dc-2acb34e56861.png)
Before changing it, I got:
118400: acc=0.8124831081081081
(0.02992859903971354, 0.8136)

After removing the duplicated code, I got:
118400: acc=0.8166638513513513
(0.02971452433268229, 0.81755)

#8 
