### PR TITLE
Separate two ideas to clean the confusion.

### DIFF
--- a/computer-vision-pytorch/5-convolutional-networks.ipynb
+++ b/computer-vision-pytorch/5-convolutional-networks.ipynb
@@ -172,7 +172,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see that this network contains around 50k trainable parameters, compared to around 80k in fully-connected multi-layered networks. This allows us to achieve good results even on smaller datasets, because convolutional networks generalize much better."
+    "You can see that this network contains around 50k trainable parameters, compared to around 80k in fully-connected multi-layered networks. In addition, this network allows us to achieve good results even on smaller datasets, because convolutional networks generalize much better."
    ]
   },
   {


### PR DESCRIPTION
Orginal:

You can see that this network contains around 50k trainable parameters, compared to around 80k in fully-connected multi-layered networks. This allows us to achieve good results even on smaller datasets, because convolutional networks generalize much better.

This confuses the reader to think that fewer trainable parameters allow us to achieve a good result. Thus, I suggest separating two different ideass.

If I am wrong, please feel free to close it